### PR TITLE
Add a filter to clear a configured list of cookies if a web session is invalidated

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>${project.parent.artifactId}-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -37,6 +37,10 @@
                 <exclusion>
                     <groupId>javax.servlet</groupId>
                     <artifactId>jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -55,12 +59,16 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>jsp-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/omod/src/main/java/org/openmrs/module/authentication/web/CookieClearingFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/CookieClearingFilter.java
@@ -1,0 +1,111 @@
+package org.openmrs.module.authentication.web;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.module.authentication.AuthenticationConfig;
+import org.openmrs.web.WebConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This servlet filter exists to remove session cookies when a user logs out.
+ * <p/>
+ * This filter is configurable at runtime using the following properties:
+ * <ul>
+ *     <li><tt>authentication.cookies.clearOnLogout = true | false </tt> determines whether to clear cookies on logout. If
+ *     not set to <tt>true</tt>, this filter takes no actions.</li>
+ *     <li><tt>authentication.cookies.toClear = comma separated list of cookies to clear</tt>
+ *     determines the cookies we will try to clear. If unset, no action will be taken. If set, the named cookies will only be
+ *     cleared if they are present on the incoming request.</li>
+ * </ul>
+ */
+public class CookieClearingFilter implements Filter {
+	
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+	
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	
+	}
+	
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+			throws IOException, ServletException {
+		
+		if (servletRequest instanceof HttpServletRequest && servletResponse instanceof HttpServletResponse) {
+			HttpServletRequest request = (HttpServletRequest) servletRequest;
+			HttpServletResponse response = (HttpServletResponse) servletResponse;
+			
+			if (!AuthenticationConfig.isConfigurationCacheEnabled()) {
+				AuthenticationConfig.reloadConfigFromRuntimeProperties(WebConstants.WEBAPP_NAME);
+			}
+			
+			// if an earlier filter has already written a response, we cannot do anything
+			if (response.isCommitted()) {
+				filterChain.doFilter(servletRequest, servletResponse);
+				return;
+			}
+			
+			boolean isEnabled = AuthenticationConfig.getBoolean("authentication.cookies.clearOnLogout", false);
+			String[] cookiesToClear = new String[0];
+			if (isEnabled) {
+				String cookiesToClearSetting = AuthenticationConfig.getProperty("authentication.cookies.toClear", "");
+				isEnabled = StringUtils.isNotBlank(cookiesToClearSetting);
+				if (isEnabled) {
+					cookiesToClear = Arrays.stream(cookiesToClearSetting.split("\\s*,\\s*")).map(String::trim).toArray(
+							String[]::new);
+				}
+			}
+			
+			boolean requestHasSession = false;
+			if (isEnabled) {
+				// we need to track whether this request initially was part of a session
+				// if it was and there is no valid request at the end of the session, we clear the session cookies
+				requestHasSession = request.getRequestedSessionId() != null;
+			}
+			
+			// handle the request
+			filterChain.doFilter(request, response);
+			
+			if (isEnabled && !response.isCommitted()) {
+				HttpSession session = request.getSession(false);
+				// session was invalidated
+				if (session == null && requestHasSession) {
+					for (Cookie cookie : request.getCookies()) {
+						for (String cookieToClear : cookiesToClear) {
+							if (cookieToClear.equalsIgnoreCase(cookie.getName())) {
+								// NB This doesn't preserve the HttpOnly flag, but it seems irrelevant since Max-Age: 0 expires
+								// the cookie, i.e., a well-behaved user agent will throw it away and, in any case, we delete
+								// the value
+								Cookie clearedCookie = (Cookie) cookie.clone();
+								clearedCookie.setValue(null);
+								clearedCookie.setMaxAge(0);
+								response.addCookie(clearedCookie);
+								break;
+							}
+						}
+					}
+				}
+			}
+		} else {
+			filterChain.doFilter(servletRequest, servletResponse);
+		}
+	}
+	
+	@Override
+	public void destroy() {
+	
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -24,6 +24,17 @@
 		<aware_of_module>org.openmrs.module.webservices.rest</aware_of_module>
 	</aware_of_modules>
 
+	<!-- Order of filters is important and the cookie clearing filter should come before the authentication filter -->
+	<filter>
+		<filter-name>cookieClearingFilter</filter-name>
+		<filter-class>org.openmrs.module.authentication.web.CookieClearingFilter</filter-class>
+	</filter>
+
+	<filter-mapping>
+		<filter-name>authenticationFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
 	<filter>
 		<filter-name>authenticationFilter</filter-name>
 		<filter-class>org.openmrs.module.authentication.web.AuthenticationFilter</filter-class>

--- a/omod/src/test/java/org/openmrs/module/authentication/web/CookieClearingFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/CookieClearingFilterTest.java
@@ -1,0 +1,224 @@
+package org.openmrs.module.authentication.web;
+
+import javax.servlet.GenericServlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.authentication.AuthenticationConfig;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class CookieClearingFilterTest extends BaseWebAuthenticationTest {
+	
+	CookieClearingFilter filter;
+	
+	MockHttpServletRequest request;
+	
+	MockHttpServletResponse response;
+	
+	MockHttpSession session;
+	
+	MockFilterChain chain;
+	
+	@Override
+	@BeforeEach
+	public void setup() {
+		super.setup();
+		
+		filter = new CookieClearingFilter();
+		session = new MockHttpSession();
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		chain = new MockFilterChain();
+	}
+	
+	@Test
+	void shouldClearCookiesIfSessionEnded() throws Exception {
+		// arrange
+		createChainThatInvalidatesSession();
+		clearJSessionIdOnLogout();
+		createSessionWithId("1234");
+		
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(1, cookies.length, "Expected only a single cookie");
+		assertTrue(cookies[0].getMaxAge() <= 0, "Expected Max-Age to be zero or a negative number");
+	}
+	
+	@Test
+	void shouldNotClearCookiesIfSessionNotInvalidated() throws Exception {
+		// arrange
+		clearJSessionIdOnLogout();
+		createSessionWithId("1234");
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(0, cookies.length, "Expected no cookies in response");
+	}
+	
+	@Test
+	void shouldNotClearCookiesIfNewSessionCreatedButNotInvalidated() throws Exception {
+		// arrange
+		createChainThatInvalidatesSession();
+		clearJSessionIdOnLogout();
+		createSessionWithId("1234", true);
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(1, cookies.length, "Expected no cookies in response");
+	}
+	
+	@Test
+	void shouldNotClearCookiesIfNewSessionCreatedAndInvalidatedInOneRequest() throws Exception {
+		// arrange
+		clearJSessionIdOnLogout();
+		createSessionWithId("1234", true);
+		
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(1, cookies.length, "Expected the new session cookie in response");
+		assertTrue(cookies[0].getMaxAge() > 0, "Expected Max-Age to be set to some future value");
+	}
+	
+	@Test
+	void shouldClearAllConfiguredCookies() throws Exception {
+		// arrange
+		createChainThatInvalidatesSession();
+		AuthenticationConfig.setProperty("authentication.cookies.clearOnLogout", Boolean.TRUE.toString());
+		AuthenticationConfig.setProperty("authentication.cookies.toClear", "JSESSIONID,AnotherCookie");
+		createSessionWithId("1234");
+		// add our non-session cookie
+		{
+			Cookie myOtherCookie = new Cookie("AnotherCookie", UUID.randomUUID().toString());
+			Cookie[] requestCookies = request.getCookies();
+			Cookie[] cookies = new Cookie[requestCookies.length + 1];
+			System.arraycopy(requestCookies, 0, cookies, 0, requestCookies.length);
+			cookies[requestCookies.length] = myOtherCookie;
+			request.setCookies(cookies);
+		}
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(2, cookies.length, "Expected two cookies");
+		for (Cookie cookie : cookies) {
+			assertTrue(cookie.getMaxAge() <= 0, "Expected Max-Age to be less than or equal to 0 for cookie " + cookie.getName());
+		}
+	}
+	
+	@Test
+	void shouldClearAllConfiguredCookiesIgnoringWhitespace() throws Exception {
+		// arrange
+		createChainThatInvalidatesSession();
+		AuthenticationConfig.setProperty("authentication.cookies.clearOnLogout", Boolean.TRUE.toString());
+		AuthenticationConfig.setProperty("authentication.cookies.toClear", " JSESSIONID \t,     AnotherCookie     ");
+		createSessionWithId("1234");
+		// add our non-session cookie
+		{
+			Cookie myOtherCookie = new Cookie("AnotherCookie", UUID.randomUUID().toString());
+			Cookie[] requestCookies = request.getCookies();
+			Cookie[] cookies = new Cookie[requestCookies.length + 1];
+			System.arraycopy(requestCookies, 0, cookies, 0, requestCookies.length);
+			cookies[requestCookies.length] = myOtherCookie;
+			request.setCookies(cookies);
+		}
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		Cookie[] cookies = response.getCookies();
+		assertEquals(2, cookies.length, "Expected two cookies");
+		for (Cookie cookie : cookies) {
+			assertTrue(cookie.getMaxAge() <= 0, "Expected Max-Age to be less than or equal to 0 for cookie " + cookie.getName());
+		}
+	}
+	
+	@Test
+	void shouldDoNothingIfNotEnabled() throws Exception {
+		// arrange
+		request = mock(MockHttpServletRequest.class);
+		response = mock(MockHttpServletResponse.class);
+		
+		// act
+		filter.doFilter(request, response, chain);
+		
+		// assert
+		verify(response, atLeastOnce()).isCommitted();
+		verifyNoMoreInteractions(request, response);
+	}
+	
+	void clearJSessionIdOnLogout() {
+		AuthenticationConfig.setProperty("authentication.cookies.clearOnLogout", Boolean.TRUE.toString());
+		AuthenticationConfig.setProperty("authentication.cookies.toClear", "JSESSIONID");
+	}
+	
+	void createChainThatInvalidatesSession() {
+		chain = new MockFilterChain(new SessionInvalidationServlet());
+	}
+	
+	void createSessionWithId(String id) {
+		createSessionWithId(id, false);
+	}
+	
+	void createSessionWithId(String id, boolean isNew) {
+		session = new MockHttpSession(null, id);
+		session.setNew(isNew);
+		request.setSession(session);
+		
+		if (!isNew) {
+			request.setRequestedSessionId(id);
+			Cookie sessionCookie = new Cookie("JSESSIONID", "1234");
+			sessionCookie.setMaxAge(60 * 60 * 2);
+			request.setCookies(sessionCookie);
+		} else {
+			Cookie sessionCookie = new Cookie("JSESSIONID", "1234");
+			sessionCookie.setMaxAge(60 * 60 * 2);
+			response.addCookie(sessionCookie);
+		}
+	}
+	
+	private static final class SessionInvalidationServlet extends GenericServlet {
+		
+		@Override
+		public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+			if (req instanceof HttpServletRequest) {
+				((HttpServletRequest) req).getSession().invalidate();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This adds a filter to this module that will clear any configured cookies if the user's session is expired during the request. The idea is that if the user's request goes to a logoff endpoint (regardless of what UI its in), we can clear any session-related cookies.

This is intended to resolve issue like in [this Talk post](https://talk.openmrs.org/t/client-cookies-are-not-getting-removed-after-server-session-invalidated/38047).