### PR TITLE
Demo: Prevent 302 redirects for SPA JSON requests during TOTP challenge

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -176,9 +176,18 @@ public class AuthenticationFilter implements Filter {
 	 * @param challengeUrl the challengeUrl to direct the response to
 	 */
 	protected void handleAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, String challengeUrl) throws IOException {
-		if (WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getNonRedirectUrls())) {
+		String acceptHeader = request.getHeader("Accept");
+		boolean isSpaRequest = acceptHeader != null && acceptHeader.contains("application/json");
+
+		if (WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getNonRedirectUrls()) || isSpaRequest) {
 			response.setHeader("Location", challengeUrl);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+			if (isSpaRequest) {
+				response.setContentType("application/json");
+				response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+				response.getWriter().write("{\"challengeRequired\": true, \"location\": \"" + challengeUrl + "\"}");
+			} else {
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+			}
 		}
 		else {
 			response.sendRedirect(challengeUrl);


### PR DESCRIPTION
### GSOC 2026 Proposal Demo
This is a Draft Proof-of-Concept PR associated with my GSOC 2026 application: *Integrate O3 with the Authentication module*.

**The Problem:**
Currently, when a user successfully passes primary authentication but requires a Two-Factor (TOTP) step, the \AuthenticationFilter\ issues an HTTP 302 redirect to a legacy \.page\ URL. This hard redirect breaks modern Single Page Application (SPA) clients like O3, which expect JSON responses.

**The Solution Demo'd Here:**
This commit modifies \AuthenticationFilter.java\ to inspect the \Accept\ header. If the incoming request is from a modern SPA expecting \pplication/json\, it safely halts the 302 redirect and instead responds natively with an HTTP 401 Unauthorized status, injecting a targeted JSON payload. 

This minor but crucial architectural pivot allows the O3 frontend to intercept the challenge and mount a native React TOTP input screen without dropping the session state.