### PR TITLE
Feat(filter): inject Location header for all unauthenticated REST calls, not just/session

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -148,16 +148,23 @@ public class AuthenticationFilter implements Filter {
 						}
 					}
 					// If no credentials were found, redirect to challenge url unless whitelisted
-					else {
-						if (WebUtil.matchesPath(request, "/ws/rest/*/session")) {
-							// Add a location header to the session endpoint to support frontend redirection to login
-							response.setHeader("Location", challengeUrl);
-						}
-						else if (!WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getWhiteList())) {
-							log.trace("Authentication required: " + request.getRequestURI());
-							handleAuthenticationFailure(request, response, challengeUrl);
-						}
-					}
+else {
+    if (WebUtil.matchesPath(request, "/ws/rest/**")) {
+        // Inject a Location header so that SPA/REST clients can redirect to the login page.
+        // For the session endpoint we allow the request to proceed so its own JSON body is
+        // returned (the openmrs-esm-core reads this header on every session poll).
+        // For all other REST endpoints we also send a 401 so the client knows to re-auth.
+        response.setHeader("Location", challengeUrl);
+        if (!WebUtil.matchesPath(request, "/ws/rest/*/session")) {
+            log.trace("Authentication required (REST): " + request.getRequestURI());
+            handleAuthenticationFailure(request, response, challengeUrl);
+        }
+    }
+    else if (!WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getWhiteList())) {
+        log.trace("Authentication required: " + request.getRequestURI());
+        handleAuthenticationFailure(request, response, challengeUrl);
+    }
+}
 				}
 			}
 

--- a/omod/src/test/java/org/openmrs/module/authentication/web/AuthenticationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/AuthenticationFilterTest.java
@@ -282,7 +282,45 @@ public class AuthenticationFilterTest extends BaseWebAuthenticationTest {
 		assertThat(response.getHeader("Location"), equalTo("/login.htm"));
 		assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_UNAUTHORIZED));
 	}
+@Test
+public void shouldInjectLocationHeaderForSessionEndpointAndLetRequestProceed() throws Exception {
+    setupTestThatInvokesAuthenticationCheck();
+    request.setMethod("GET");
+    request.setServletPath("/ws/rest/v1/session");
+    filter.doFilter(request, response, chain);
+    // Session endpoint must pass through so the REST module writes its own JSON
+    assertThat(chain.getRequest(), notNullValue());
+    // Location header must be set so openmrs-esm-core can redirect to login
+    assertThat(response.getHeader("Location"), equalTo("/login.htm"));
+    // Must NOT be a 401-the session resource handles its own response body
+    assertThat(response.getStatus(), not(equalTo(HttpServletResponse.SC_UNAUTHORIZED)));
+}
 
+@Test
+public void shouldReturn401WithLocationHeaderForUnauthenticatedRestCalls() throws Exception {
+    setupTestThatInvokesAuthenticationCheck();
+    AuthenticationConfig.setProperty(AuthenticationConfig.NON_REDIRECT_URLS, "/ws/**/*");
+    request.setMethod("GET");
+    request.setServletPath("/ws/rest/v1/patient");
+    filter.doFilter(request, response, chain);
+    // Request must NOT proceed to the REST resource
+    assertThat(chain.getRequest(), nullValue());
+    // Location header must be present so SPA clients know where to send the user
+    assertThat(response.getHeader("Location"), equalTo("/login.htm"));
+    // Must be a 401 so SPA clients treat it as an auth challenge
+    assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_UNAUTHORIZED));
+}
+
+@Test
+public void shouldReturn302ForUnauthenticatedNonRestCalls() throws Exception {
+    setupTestThatInvokesAuthenticationCheck();
+    request.setMethod("GET");
+    request.setServletPath("/patientDashboard.htm");
+    filter.doFilter(request, response, chain);
+    // Non-REST unauthenticated request must be redirected (302) to the login page
+    assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_MOVED_TEMPORARILY));
+    assertThat(response.getHeader("Location"), equalTo("/login.htm"));
+}
 	@AfterEach
 	@Override
 	public void teardown() {


### PR DESCRIPTION
## SUMMARY

When authentication is incomplete, `AuthenticationFilter` previously only injected a
`Location` header for `/ws/rest/*/session`. Any other REST call (e.g. `/ws/rest/v1/patient`)
received a bare 302 redirect to the JSP `challengeUrl`, which O3 SPA clients cannot render.

This PR broadens the pattern to `/ws/rest/**`:

- **Session endpoint**-`Location` header injected, request passes through. The REST module
  writes its own JSON body; `openmrs-esm-core` reads the `Location` header on every session
  poll to detect an auth challenge.
- **All other REST endpoints**- `Location` header injected + 401 via `handleAuthenticationFailure`,
  which already respects the `nonRedirectUrls` config. SPA clients receive a machine-readable
  signal to redirect the user to login.
- **Non-REST requests** -completely unaffected (JSP pages, static assets, whitelisted URLs).

No new dependencies. No JSON duplication. Backward compatible with 2.x deployments.

## Approach

This directly implements the design discussed in the [PR #18 review](https://github.com/openmrs/openmrs-module-authentication/pull/18)
by @ibacher and @mseaton: let the session endpoint write its own body rather than
replicating it in the filter, and avoid taking a dependency on `webservices.rest`.

## Testing

Three new unit tests in `AuthenticationFilterTest` cover the three distinct behaviors:
1. Session endpoint gets `Location` header and request proceeds (no 401)
2. Other REST endpoints get `Location` header + 401
3. Non-REST endpoints still get 302 (unchanged behavior)