### PR TITLE
test(web): add explicit coverage for ** and */session wildcard patterns in matchesPath

### DIFF
--- a/omod/src/test/java/org/openmrs/module/authentication/web/AuthenticationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/AuthenticationFilterTest.java
@@ -220,7 +220,39 @@ public class AuthenticationFilterTest extends BaseWebAuthenticationTest {
 		assertThat(WebUtil.matchesPath(request, "/openmrs/login.htm"), equalTo(true));
 		assertThat(WebUtil.matchesPath(request, "/login.html"), equalTo(false));
 	}
+    @Test
+	public void shouldMatchDoubleWildcardPatternForAllRestPaths() {
+    request.setContextPath("/");
+    request.setServletPath("/ws/rest/v1/patient");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(true));
+    request.setServletPath("/ws/rest/v1/session");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(true));
+    request.setServletPath("/ws/rest/v1/patient/923f69ae-fa1a-43db-98e6-bafcc80f5c05");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(true));
+    request.setServletPath("/ws/fhir2/R4/Patient");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(false));
+    request.setServletPath("/patientDashboard.htm");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(false));
+}
 
+@Test
+public void shouldMatchSingleSegmentWildcardOnlyForSessionEndpoint() {
+    request.setContextPath("/");
+    request.setServletPath("/ws/rest/v1/session");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/*/session"), equalTo(true));
+    request.setServletPath("/ws/rest/v2/session");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/*/session"), equalTo(true));
+    request.setServletPath("/ws/rest/v1/patient");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/*/session"), equalTo(false));
+}
+
+@Test
+public void shouldMatchDoubleWildcardButNotSingleWildcardForDeepRestPaths() {
+    request.setContextPath("/");
+    request.setServletPath("/ws/rest/v1/obs/abc-123/value");
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/**"), equalTo(true));
+    assertThat(WebUtil.matchesPath(request, "/ws/rest/*/session"), equalTo(false));
+}
 	@Test
 	public void shouldGetTheDefaultAuthenticationSchemeIfNoneConfigured() {
 		AuthenticationScheme scheme = filter.getAuthenticationScheme();


### PR DESCRIPTION
## What and why

While working on #29 (extending the `Location` header to all REST calls), I was relying on two specific patterns in `WebUtil.matchesPath()`:

- `/ws/rest/**`- to catch all unauthenticated REST requests
- `/ws/rest/*/session`-to single out the session endpoint and let it pass through

I realized neither of these patterns had any direct test coverage. The only existing tests for `matchesPath()` cover simple exact paths and the ends-with (`*`) pattern. If someone changed `WebUtil` tomorrow and broke how `**` or `*/session` behaves, nothing would catch it.

So I added 3 focused tests to the existing `AuthenticationFilterTest` that explicitly document this behavior:

- `/ws/rest/**` matches all REST sub-paths including deep UUID paths, but NOT `/ws/fhir2`
- `/ws/rest/*/session` matches only a single version segment ,so `v1/session` matches, but `v1/patient` does not
- The two patterns behave differently on deep sub-resource paths like `/ws/rest/v1/obs/abc-123/value`

## What this is not

This is not fixing anything broken. PR #29 works correctly. This just makes the path-matching behaviour explicit and regression-proof.

Relates-to: #29