### PR TITLE
ci: update release workflow to use OMRS_BOT_GH_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-      BOT_PAT: ${{ secrets.BOT_PAT }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}


### PR DESCRIPTION
PR #27 updated `build.yml` to use `BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}`
after the shared reusable workflow updated its expected secret name.

`release.yml` still had the old `BOT_PAT: ${{ secrets.BOT_PAT }}` reference
and wasn't updated at the same time. This brings it in line with `build.yml`.
```