### PR TITLE
(fix) AUT-6: Normalize TOTP code by removing whitespace before verification

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
@@ -104,7 +104,9 @@ public class TotpAuthenticationScheme extends WebAuthenticationScheme {
 			throw new ContextAuthenticationException("authentication.error.noSecretConfiguredForUser");
 		}
 		String decodedSecret = Security.decrypt(userSecret);
-		if (!verifyCode(decodedSecret, c.code)) {
+		// Normalize code to remove whitespace (some authenticator apps include spaces)
+		String normalizedCode = StringUtils.deleteWhitespace(c.code);
+		if (!verifyCode(decodedSecret, normalizedCode)) {
 			throw new ContextAuthenticationException("authentication.error.invalidCredentials");
 		}
 


### PR DESCRIPTION
## Description
Fixes TOTP verification failure when codes contain whitespace.

Some authenticator apps (e.g., Microsoft Authenticator) display codes with spaces (e.g., "123 456"),
but verification expects a continuous string.

## Solution
Normalize the input code by removing all whitespace before verification using StringUtils.deleteWhitespace.

## Testing
- Verified that codes with and without spaces are accepted

## Related Issue
AUT-6