### PR TITLE
AUT-18: Log authentication failures as warnings and prevent open redirects

### DIFF
--- a/api/src/main/java/org/openmrs/module/authentication/UserLogin.java
+++ b/api/src/main/java/org/openmrs/module/authentication/UserLogin.java
@@ -191,7 +191,7 @@ public class UserLogin implements Serializable {
         setUser(authenticated.getUser());
         validatedCredentials.add(schemeId);
         unvalidatedCredentials.remove(schemeId);
-        recordEvent(AuthenticationEvent.AUTHENTICATION_SUCCEEDED, schemeId);
+        recordEvent(AuthenticationEvent.AUTHENTICATION_SUCCEEDED, schemeId, false);
     }
 
     /**
@@ -203,7 +203,7 @@ public class UserLogin implements Serializable {
         if (validatedCredentials.isEmpty()) {
             setUser(null);
         }
-        recordEvent(AuthenticationEvent.AUTHENTICATION_FAILED, schemeId);
+        recordEvent(AuthenticationEvent.AUTHENTICATION_FAILED, schemeId, true);
     }
 
     /**
@@ -212,7 +212,7 @@ public class UserLogin implements Serializable {
     public synchronized void loginSuccessful() {
         this.loginDate = new Date();
         UserLoginTracker.addActiveLogin(this);
-        recordEvent(AuthenticationEvent.LOGIN_SUCCEEDED, null);
+        recordEvent(AuthenticationEvent.LOGIN_SUCCEEDED, null, false);
     }
 
     /**
@@ -221,7 +221,7 @@ public class UserLogin implements Serializable {
     public synchronized void loginFailed() {
         setUsername(null);
         setUser(null);
-        recordEvent(AuthenticationEvent.LOGIN_FAILED, null);
+        recordEvent(AuthenticationEvent.LOGIN_FAILED, null, true);
     }
 
     /**
@@ -229,7 +229,7 @@ public class UserLogin implements Serializable {
      */
     public synchronized void loginExpired() {
         UserLoginTracker.removeActiveLogin(this);
-        recordEvent(AuthenticationEvent.LOGIN_EXPIRED, null);
+        recordEvent(AuthenticationEvent.LOGIN_EXPIRED, null, true);
     }
 
     /**
@@ -238,14 +238,14 @@ public class UserLogin implements Serializable {
     public synchronized void logoutSucceeded() {
         this.logoutDate = new Date();
         UserLoginTracker.removeActiveLogin(this);
-        recordEvent(AuthenticationEvent.LOGOUT_SUCCEEDED, null);
+        recordEvent(AuthenticationEvent.LOGOUT_SUCCEEDED, null, false);
     }
 
     /**
      * Records a failed logout from the system
      */
     public synchronized void logoutFailed() {
-        recordEvent(AuthenticationEvent.LOGOUT_FAILED, null);
+        recordEvent(AuthenticationEvent.LOGOUT_FAILED, null, true);
     }
 
     /**
@@ -269,7 +269,7 @@ public class UserLogin implements Serializable {
      * @param event the event to log
      * @param schemeId the schemeId that the event refers to, if this corresponds to a specific authentication scheme
      */
-    public synchronized void recordEvent(String event, String schemeId) {
+    public synchronized void recordEvent(String event, String schemeId, boolean isWarning) {
         events.add(new AuthenticationEvent(event));
         if (log.isInfoEnabled()) {
             try {
@@ -281,7 +281,12 @@ public class UserLogin implements Serializable {
                 ThreadContext.put("username", getUsername());
                 ThreadContext.put("userId", getUserId() == null ? null : getUserId().toString());
                 ThreadContext.put("lastActivityDate", AuthenticationUtil.formatIsoDate(getLastActivityDate()));
-                log.info(EVENT_MARKER, ThreadContext.getContext().toString());
+                if (isWarning) {
+                    log.warn(EVENT_MARKER, ThreadContext.getContext().toString());
+                }
+                else {
+                    log.info(EVENT_MARKER, ThreadContext.getContext().toString());
+                }
             }
             finally {
                 ThreadContext.clearAll();

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -19,7 +19,6 @@ import org.openmrs.module.authentication.AuthenticationCredentials;
 import org.openmrs.module.authentication.DelegatingAuthenticationScheme;
 import org.openmrs.module.authentication.UserLogin;
 import org.openmrs.module.authentication.UserLoginTracker;
-import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.WebConstants;
 import org.springframework.util.AntPathMatcher;
 

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -210,7 +210,7 @@ public class AuthenticationFilter implements Filter {
 		if (StringUtils.isBlank(redirect)) {
 			redirect = request.getParameter("refererURL");
 		}
-		if (StringUtils.isNotBlank(redirect)) {
+		if (StringUtils.isNotBlank(redirect) && WebUtil.isLocalUrl(redirect)) {
 			return WebUtil.contextualizeUrl(request, redirect);
 		}
 		

--- a/omod/src/main/java/org/openmrs/module/authentication/web/WebUtil.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/WebUtil.java
@@ -64,4 +64,18 @@ public class WebUtil {
         }
         return url;
     }
+
+    /**
+     * It is considered safe if it's a relative URL.
+     * Absolute URLs are considered unsafe.
+     *
+     * @param url The URL to check.
+     * @return true if the URL is safe for redirection.
+     */
+    public static boolean isLocalUrl(String url) {
+        if (url == null) {
+            return false;
+        }
+        return !url.contains("://") && !url.startsWith("//");
+    }
 }


### PR DESCRIPTION
Fixes AUT-18
https://openmrs.atlassian.net/browse/AUT-18

Changes made:

Updated UserLogin.recordEvent to accept an isWarning flag, logging authentication failures, login failures, and expirations as warnings instead of info.

Added WebUtil.isLocalUrl to validate that a given URL is relative.

Updated AuthenticationFilter.determineSuccessRedirectUrl to use WebUtil.isLocalUrl to ensure redirection only occurs to local URLs, preventing open redirect vulnerabilities.

* Updated `UserLogin.recordEvent` to accept an `isWarning` flag, logging authentication failures, login failures, and expirations as warnings instead of info.
* Added `WebUtil.isLocalUrl` to validate that a given URL is relative.
* Updated `AuthenticationFilter.determineSuccessRedirectUrl` to use `WebUtil.isLocalUrl` to ensure redirection only occurs to local URLs, preventing open redirect vulnerabilities.