### PR TITLE
docs: add O3 integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,12 @@ Then, configure a `log4j2.xml` file within your application data directory (or w
   </Loggers>
 </Configuration>
 ```
+
+
+## OpenMRS 3 (O3) Integration
+
+The Authentication Module is being integrated with the modern O3 frontend as part of the GSoC 2026 project.  
+See the active work in:
+- [PR #18](https://github.com/openmrs/openmrs-module-authentication/pull/18) — Introduce changes needed to support TOTP in O3
+
+This small documentation update helps new contributors and GSoC applicants quickly find the ongoing O3 + TOTP integration effort.


### PR DESCRIPTION
Adds a short O3 section at the bottom of the README so new contributors and GSoC applicants can quickly find the ongoing TOTP + O3 work (PR #18).

This is my first contribution toward the GSoC 2026 "Integrate O3 with the Authentication Module" project.