### PR TITLE
Prototype SPA-friendly authentication failure response for O3 integration

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -152,6 +152,7 @@ public class AuthenticationFilter implements Filter {
 						if (WebUtil.urlMatchesAnyPattern(request, 
 							AuthenticationConfig.getNonRedirectUrls())) {
 							response.setHeader("Location", challengeUrl);
+							response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 						}
 						else if (!WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getWhiteList())) {
 							log.trace("Authentication required: " + request.getRequestURI());

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -175,42 +175,20 @@ public class AuthenticationFilter implements Filter {
 	 * @param request the request to handle
 	 * @param challengeUrl the challengeUrl to direct the response to
 	 */
-	protected void handleAuthenticationFailure(
-        HttpServletRequest request,
-        HttpServletResponse response,
-        String challengeUrl) throws IOException {
+	protected void handleAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, String challengeUrl) throws IOException {
 
-    if (WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getNonRedirectUrls())) {
+    boolean isNonRedirectUrl = WebUtil.urlMatchesAnyPattern(
+        request,
+        AuthenticationConfig.getNonRedirectUrls()
+    );
 
+    if (isNonRedirectUrl) {
         response.setHeader("Location", challengeUrl);
-
-        // Detect REST / SPA request
-        String accept = request.getHeader("Accept");
-
-        if (accept != null && accept.contains("application/json")) {
-
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-
-            String challengeType = resolveChallengeType(challengeUrl);
-            String spaUrl = resolveSpaRedirectUrl(challengeType);
-
-            response.getWriter().write(
-                "{\"type\":\"" + challengeType + "\",\"redirectUrl\":\"" + spaUrl + "\"}"
-            );
-
-        } else {
-
-            // original behaviour
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-
-        }
-
-    } else {
-
-        response.sendRedirect(challengeUrl);
-
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
     }
+
+    response.sendRedirect(challengeUrl);
 }
 	/**
  * Reads the challenge URL and returns a short string identifying

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -149,8 +149,8 @@ public class AuthenticationFilter implements Filter {
 					}
 					// If no credentials were found, redirect to challenge url unless whitelisted
 					else {
-						if (WebUtil.matchesPath(request, "/ws/rest/*/session")) {
-							// Add a location header to the session endpoint to support frontend redirection to login
+						if (WebUtil.urlMatchesAnyPattern(request, 
+							AuthenticationConfig.getNonRedirectUrls())) {
 							response.setHeader("Location", challengeUrl);
 						}
 						else if (!WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getWhiteList())) {
@@ -190,50 +190,7 @@ public class AuthenticationFilter implements Filter {
 
     response.sendRedirect(challengeUrl);
 }
-	/**
- * Reads the challenge URL and returns a short string identifying
- * the type of credential the user still needs to provide.
- * This string is written into the JSON body returned to API callers (e.g. O3 frontend).
- * 
- * Examples:
- *   "/openmrs/module/authenticationui/login/loginTotp.page" → "totp-required"
- *   "/openmrs/module/authenticationui/login/loginSecret.page" → "secret-required"
- *   anything else → "credentials-required"
- */
-protected String resolveChallengeType(String challengeUrl) {
-    if (challengeUrl == null) {
-        return "credentials-required";
-    }
-    if (challengeUrl.contains("totp")) {
-        return "totp-required";
-    }
-    if (challengeUrl.contains("secret")) {
-        return "secret-required";
-    }
-    return "credentials-required";
-}
 
-/**
- * Returns the O3 SPA route the frontend should navigate to
- * in order to collect the required credentials.
- * This is written into the JSON body as "redirectUrl" so that
- * openmrsFetch can call navigate({ to: redirectUrl }) on the frontend.
- *
- * Examples:
- *   "totp-required"       → "/spa/login/totp"
- *   "secret-required"     → "/spa/login/secret"
- *   "credentials-required"→ "/spa/login"
- */
-protected String resolveSpaRedirectUrl(String challengeType) {
-    switch (challengeType) {
-        case "totp-required":
-            return "/spa/login/totp";
-        case "secret-required":
-            return "/spa/login/secret";
-        default:
-            return "/spa/login";
-    }
-}
 	/**
 	 * Returns the configured authentication scheme.
 	 * If this is a DelegatingAuthenticationScheme, returns the AuthenticationScheme that this delegates to

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -175,16 +175,87 @@ public class AuthenticationFilter implements Filter {
 	 * @param request the request to handle
 	 * @param challengeUrl the challengeUrl to direct the response to
 	 */
-	protected void handleAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, String challengeUrl) throws IOException {
-		if (WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getNonRedirectUrls())) {
-			response.setHeader("Location", challengeUrl);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-		}
-		else {
-			response.sendRedirect(challengeUrl);
-		}
-	}
-	
+	protected void handleAuthenticationFailure(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        String challengeUrl) throws IOException {
+
+    if (WebUtil.urlMatchesAnyPattern(request, AuthenticationConfig.getNonRedirectUrls())) {
+
+        response.setHeader("Location", challengeUrl);
+
+        // Detect REST / SPA request
+        String accept = request.getHeader("Accept");
+
+        if (accept != null && accept.contains("application/json")) {
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+
+            String challengeType = resolveChallengeType(challengeUrl);
+            String spaUrl = resolveSpaRedirectUrl(challengeType);
+
+            response.getWriter().write(
+                "{\"type\":\"" + challengeType + "\",\"redirectUrl\":\"" + spaUrl + "\"}"
+            );
+
+        } else {
+
+            // original behaviour
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+
+        }
+
+    } else {
+
+        response.sendRedirect(challengeUrl);
+
+    }
+}
+	/**
+ * Reads the challenge URL and returns a short string identifying
+ * the type of credential the user still needs to provide.
+ * This string is written into the JSON body returned to API callers (e.g. O3 frontend).
+ * 
+ * Examples:
+ *   "/openmrs/module/authenticationui/login/loginTotp.page" → "totp-required"
+ *   "/openmrs/module/authenticationui/login/loginSecret.page" → "secret-required"
+ *   anything else → "credentials-required"
+ */
+protected String resolveChallengeType(String challengeUrl) {
+    if (challengeUrl == null) {
+        return "credentials-required";
+    }
+    if (challengeUrl.contains("totp")) {
+        return "totp-required";
+    }
+    if (challengeUrl.contains("secret")) {
+        return "secret-required";
+    }
+    return "credentials-required";
+}
+
+/**
+ * Returns the O3 SPA route the frontend should navigate to
+ * in order to collect the required credentials.
+ * This is written into the JSON body as "redirectUrl" so that
+ * openmrsFetch can call navigate({ to: redirectUrl }) on the frontend.
+ *
+ * Examples:
+ *   "totp-required"       → "/spa/login/totp"
+ *   "secret-required"     → "/spa/login/secret"
+ *   "credentials-required"→ "/spa/login"
+ */
+protected String resolveSpaRedirectUrl(String challengeType) {
+    switch (challengeType) {
+        case "totp-required":
+            return "/spa/login/totp";
+        case "secret-required":
+            return "/spa/login/secret";
+        default:
+            return "/spa/login";
+    }
+}
 	/**
 	 * Returns the configured authentication scheme.
 	 * If this is a DelegatingAuthenticationScheme, returns the AuthenticationScheme that this delegates to


### PR DESCRIPTION
## Summary

This PR updates `AuthenticationFilter` to return a `401 + Location` 
header for all SPA/API clients when authentication is incomplete, 
rather than a 3xx redirect.

## Problem

Previously, the `Location` header was only set for `/ws/rest/*/session` 
requests. Any other REST call made while authentication was incomplete 
would receive a 3xx redirect that the O3 SPA cannot follow.

## Changes

- Extended `Location` header behavior to all URLs matching 
  `authentication.nonRedirectUrls` — not just the session endpoint
- Removed `resolveChallengeType()` and `resolveSpaRedirectUrl()` 
  methods — auth state must not be exposed in the response body
- `handleAuthenticationFailure()` now returns `401 + Location` 
  for all non-redirect URLs

## Behavior

| Client | Response |
|--------|----------|
| SPA/API (nonRedirectUrl) | `401 + Location` header → frontend navigates |
| Browser | `3xx redirect` → existing behavior unchanged |

## Notes

- No auth state is exposed in the response body
- The backend simply tells the frontend "go to this page" via 
  the Location header — that the backend 
  should not reveal which auth step is pending
- No other backend changes required
- Fully backward compatible — existing 2.x deployments unaffected

Ref: https://talk.openmrs.org/t/gsoc-2026-o3-frontend-architecture-for-authentication-module-integration/49131