### PR TITLE
AUT-18: Log auth failures as warnings and fix open redirect with robust URI validation

### DIFF
--- a/api/src/main/java/org/openmrs/module/authentication/UserLogin.java
+++ b/api/src/main/java/org/openmrs/module/authentication/UserLogin.java
@@ -203,7 +203,7 @@ public class UserLogin implements Serializable {
         if (validatedCredentials.isEmpty()) {
             setUser(null);
         }
-        recordEvent(AuthenticationEvent.AUTHENTICATION_FAILED, schemeId);
+        recordEvent(AuthenticationEvent.AUTHENTICATION_FAILED, schemeId, true);
     }
 
     /**
@@ -221,7 +221,7 @@ public class UserLogin implements Serializable {
     public synchronized void loginFailed() {
         setUsername(null);
         setUser(null);
-        recordEvent(AuthenticationEvent.LOGIN_FAILED, null);
+        recordEvent(AuthenticationEvent.LOGIN_FAILED, null, true);
     }
 
     /**
@@ -229,7 +229,7 @@ public class UserLogin implements Serializable {
      */
     public synchronized void loginExpired() {
         UserLoginTracker.removeActiveLogin(this);
-        recordEvent(AuthenticationEvent.LOGIN_EXPIRED, null);
+        recordEvent(AuthenticationEvent.LOGIN_EXPIRED, null, true);
     }
 
     /**
@@ -245,7 +245,7 @@ public class UserLogin implements Serializable {
      * Records a failed logout from the system
      */
     public synchronized void logoutFailed() {
-        recordEvent(AuthenticationEvent.LOGOUT_FAILED, null);
+        recordEvent(AuthenticationEvent.LOGOUT_FAILED, null, true);
     }
 
     /**
@@ -270,21 +270,38 @@ public class UserLogin implements Serializable {
      * @param schemeId the schemeId that the event refers to, if this corresponds to a specific authentication scheme
      */
     public synchronized void recordEvent(String event, String schemeId) {
+        recordEvent(event, schemeId, false);
+    }
+
+    public synchronized void recordEvent(String event, String schemeId, boolean isWarning) {
         events.add(new AuthenticationEvent(event));
-        if (log.isInfoEnabled()) {
-            try {
-                ThreadContext.put("event", event);
-                ThreadContext.put("schemeId", schemeId);
-                ThreadContext.put("loginId", getLoginId());
-                ThreadContext.put("httpSessionId", getHttpSessionId());
-                ThreadContext.put("ipAddress", getIpAddress());
-                ThreadContext.put("username", getUsername());
-                ThreadContext.put("userId", getUserId() == null ? null : getUserId().toString());
-                ThreadContext.put("lastActivityDate", AuthenticationUtil.formatIsoDate(getLastActivityDate()));
-                log.info(EVENT_MARKER, ThreadContext.getContext().toString());
+        if (isWarning) {
+            if (log.isWarnEnabled()) {
+                try {
+                    ThreadContext.put("loginId", getLoginId());
+                    ThreadContext.put("ipAddress", getIpAddress());
+                    ThreadContext.put("username", getUsername());
+                    ThreadContext.put("userId", getUserId() == null ? null : getUserId().toString());
+                    ThreadContext.put("lastActivityDate", AuthenticationUtil.formatIsoDate(getLastActivityDate()));
+                    log.warn(EVENT_MARKER, ThreadContext.getContext().toString());
+                }
+                finally {
+                    ThreadContext.clearAll();
+                }
             }
-            finally {
-                ThreadContext.clearAll();
+        } else {
+            if (log.isInfoEnabled()) {
+                try {
+                    ThreadContext.put("loginId", getLoginId());
+                    ThreadContext.put("ipAddress", getIpAddress());
+                    ThreadContext.put("username", getUsername());
+                    ThreadContext.put("userId", getUserId() == null ? null : getUserId().toString());
+                    ThreadContext.put("lastActivityDate", AuthenticationUtil.formatIsoDate(getLastActivityDate()));
+                    log.info(EVENT_MARKER, ThreadContext.getContext().toString());
+                }
+                finally {
+                    ThreadContext.clearAll();
+                }
             }
         }
     }

--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -19,7 +19,6 @@ import org.openmrs.module.authentication.AuthenticationCredentials;
 import org.openmrs.module.authentication.DelegatingAuthenticationScheme;
 import org.openmrs.module.authentication.UserLogin;
 import org.openmrs.module.authentication.UserLoginTracker;
-import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.WebConstants;
 import org.springframework.util.AntPathMatcher;
 
@@ -210,7 +209,7 @@ public class AuthenticationFilter implements Filter {
 		if (StringUtils.isBlank(redirect)) {
 			redirect = request.getParameter("refererURL");
 		}
-		if (StringUtils.isNotBlank(redirect)) {
+		if (StringUtils.isNotBlank(redirect) && WebUtil.isLocalUrl(redirect)) {
 			return WebUtil.contextualizeUrl(request, redirect);
 		}
 		

--- a/omod/src/main/java/org/openmrs/module/authentication/web/WebUtil.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/WebUtil.java
@@ -2,6 +2,9 @@ package org.openmrs.module.authentication.web;
 
 import org.springframework.util.AntPathMatcher;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
@@ -63,5 +66,39 @@ public class WebUtil {
             url = request.getContextPath() + (url.startsWith("/") ? "" : "/") + url;
         }
         return url;
+    }
+
+    /**
+     * Checks whether a URL is local (relative) and safe for redirection.
+     * Rejects absolute URLs, protocol-relative URLs, and javascript: URLs.
+     * Uses URI parsing to handle encoded and edge-case URLs safely.
+     *
+     * @param url The URL to check.
+     * @return true if the URL is safe for redirection.
+     */
+    public static boolean isLocalUrl(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            return false;
+        }
+        // Reject protocol-relative URLs like //evil.com
+        if (url.startsWith("//")) {
+            return false;
+        }
+        try {
+            URI uri = new URI(url);
+            // If a scheme is present (http, https, javascript, etc.) reject it
+            if (uri.getScheme() != null) {
+                return false;
+            }
+            // If a host is present, it's absolute - reject it
+            if (uri.getHost() != null) {
+                return false;
+            }
+        }
+        catch (URISyntaxException e) {
+            // If URL can't be parsed, reject it to be safe
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## JIRA Issue
https://openmrs.atlassian.net/browse/AUT-18?focusedCommentId=193039

## Description of what I changed

This PR addresses AUT-18 with improvements over the existing approach:

### 1. Log authentication failures as warnings
- Added overloaded `recordEvent(event, schemeId, boolean isWarning)` method
- Kept original `recordEvent(event, schemeId)` for **backward compatibility** (no breaking API change)
- Failure events (AUTHENTICATION_FAILED, LOGIN_FAILED, LOGIN_EXPIRED, LOGOUT_FAILED) now log at WARN level
- Used correct `log.isWarnEnabled()` guard for warning-level logs

### 2. Prevent open redirect vulnerability
- Added `WebUtil.isLocalUrl(url)` using `java.net.URI` parsing
- Rejects absolute URLs, protocol-relative URLs (//evil.com), javascript: URLs, and encoded variants
- More robust than simple string checks for `://`
- Applied the check in `AuthenticationFilter.determineSuccessRedirectUrl()`

### 3. Removed unused import
- Removed `import org.openmrs.util.OpenmrsConstants` from AuthenticationFilter.java

## Checklist
- [x] My IDE is configured to follow the code style of this project
- [x] I ran mvn clean package before creating this pull request
- [x] All new and existing tests passed
- [x] My pull request is based on the latest changes of the main branch

cc @mseaton @ibacher @dkayiwa @mogoodrich - requesting review when you get a chance. Thank you!