### PR TITLE
AUT-18: log authentication failures at warn level instead of debug

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/AuthenticationFilter.java
@@ -143,7 +143,7 @@ public class AuthenticationFilter implements Filter {
 						}
 						// If authentication fails, redirect back to re-initiate auth
 						catch (Exception e) {
-							log.debug("Authentication failed: " + request.getRequestURI());
+							log.warn("Authentication failed: " + request.getRequestURI());
 							handleAuthenticationFailure(request, response, challengeUrl);
 						}
 					}


### PR DESCRIPTION
## Issue I worked on 
[AUT-18]-(https://openmrs.atlassian.net/browse/AUT-18)

Authentication failures were logged at `debug` level in `AuthenticationFilter`. In production environments where debug logging is typically disabled, these failures are completely invisible, meaning failed login attempts leave no trace in the logs.

Changed to `warn` so authentication failures are visible in standard production logs without needing to enable debug mode.


[AUT-18]: https://openmrs.atlassian.net/browse/AUT-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ