### PR TITLE
Add unit tests for UserLoginTrackerAuth tests userlogintracker

### DIFF
--- a/api/src/test/java/org/openmrs/module/authentication/AuthenticationUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/authentication/AuthenticationUtilTest.java
@@ -1,0 +1,96 @@
+package org.openmrs.module.authentication;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link AuthenticationUtil}.
+ */
+public class AuthenticationUtilTest {
+
+    @Test
+    public void getBoolean_shouldReturnDefaultWhenValueIsBlank() {
+        assertTrue(AuthenticationUtil.getBoolean(null, true));
+        assertFalse(AuthenticationUtil.getBoolean("   ", false));
+    }
+
+    @Test
+    public void getBoolean_shouldParseNonBlankValues() {
+        assertTrue(AuthenticationUtil.getBoolean("true", false));
+        assertFalse(AuthenticationUtil.getBoolean("false", true));
+    }
+
+    @Test
+    public void getInteger_shouldReturnDefaultWhenValueIsBlank() {
+        assertEquals(Integer.valueOf(5), AuthenticationUtil.getInteger(null, 5));
+        assertEquals(Integer.valueOf(10), AuthenticationUtil.getInteger("   ", 10));
+    }
+
+    @Test
+    public void getInteger_shouldParseNonBlankValues() {
+        assertEquals(Integer.valueOf(123), AuthenticationUtil.getInteger("123", 0));
+    }
+
+    @Test
+    public void getStringList_shouldReturnEmptyListForBlankValue() {
+        List<String> result = AuthenticationUtil.getStringList("   ", ",");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getStringList_shouldSplitStringByDelimiter() {
+        List<String> result = AuthenticationUtil.getStringList("one,two,three", ",");
+        assertEquals(Arrays.asList("one", "two", "three"), result);
+    }
+
+    @Test
+    public void getPropertiesWithPrefix_shouldFilterAndStripPrefixWhenRequested() {
+        Properties props = new Properties();
+        props.setProperty("auth.key1", "value1");
+        props.setProperty("auth.key2", "value2");
+        props.setProperty("other.key", "ignored");
+
+        Properties result = AuthenticationUtil.getPropertiesWithPrefix(props, "auth.", true);
+
+        assertEquals(2, result.size());
+        assertEquals("value1", result.getProperty("key1"));
+        assertEquals("value2", result.getProperty("key2"));
+        assertNull(result.getProperty("other.key"));
+    }
+
+    @Test
+    public void getPropertiesWithPrefix_shouldKeepPrefixWhenNotStripping() {
+        Properties props = new Properties();
+        props.setProperty("auth.key1", "value1");
+        props.setProperty("auth.key2", "value2");
+
+        Properties result = AuthenticationUtil.getPropertiesWithPrefix(props, "auth.", false);
+
+        assertEquals(2, result.size());
+        assertEquals("value1", result.getProperty("auth.key1"));
+        assertEquals("value2", result.getProperty("auth.key2"));
+    }
+
+    @Test
+    public void formatIsoDate_shouldReturnNullWhenDateIsNull() {
+        assertNull(AuthenticationUtil.formatIsoDate(null));
+    }
+
+    @Test
+    public void formatIsoDate_shouldFormatDateInIsoPattern() {
+        // Use a fixed Date instance so the output is deterministic.
+        Date date = new Date(0L); // 1970-01-01T00:00:00.000 UTC (epoch)
+        String formatted = AuthenticationUtil.formatIsoDate(date);
+
+        assertNotNull(formatted);
+        assertTrue("Expected formatted date to start with 1970-01-01", formatted.startsWith("1970-01-01"));
+        assertEquals("Expected length yyyy-MM-dd'T'HH:mm:ss,SSS", 23, formatted.length());
+    }
+}

--- a/api/src/test/java/org/openmrs/module/authentication/UserLoginTrackerTest.java
+++ b/api/src/test/java/org/openmrs/module/authentication/UserLoginTrackerTest.java
@@ -1,0 +1,94 @@
+
+//Unit tests for {@link UserLoginTracker}.
+
+/**
+ * These tests verify both the ThreadLocal tracking of a single UserLogin
+ * per thread, and the global collection of active logins.
+ */
+
+package org.openmrs.module.authentication;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.User;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+
+public class UserLoginTrackerTest extends BaseAuthenticationTest {
+
+    private UserLogin buildLogin(Integer userId, String loginId) {
+        UserLogin login = new UserLogin();
+        User user = new User();
+        user.setUserId(userId);
+        login.setUser(user);
+        // loginId is generated in the constructor, but for tracking we rely on getLoginId()
+        // in the tracker map; we can't override it, so we just use whatever is generated.
+        // We still keep loginId parameter in case in future we want to assert something different.
+        return login;
+    }
+
+    @Test
+    public void setLoginOnThread_shouldAssociateLoginWithCurrentThread() {
+        UserLogin login = buildLogin(1, "ignored");
+
+        UserLoginTracker.setLoginOnThread(login);
+
+        UserLogin result = UserLoginTracker.getLoginOnThread();
+        assertThat(result, notNullValue());
+        assertThat(result.getUser(), notNullValue());
+        assertThat(result.getUser().getUserId(), equalTo(1));
+    }
+
+    @Test
+    public void removeLoginFromThread_shouldClearLoginFromCurrentThread() {
+        UserLogin login = buildLogin(1, "ignored");
+
+        UserLoginTracker.setLoginOnThread(login);
+        UserLoginTracker.removeLoginFromThread();
+
+        assertThat(UserLoginTracker.getLoginOnThread(), nullValue());
+    }
+
+    @Test
+    public void addActiveLogin_shouldAddLoginToActiveLoginsMap() {
+        UserLogin login = buildLogin(1, "ignored");
+
+        UserLoginTracker.addActiveLogin(login);
+
+        Map<String, UserLogin> active = UserLoginTracker.getActiveLogins();
+        assertThat(active.isEmpty(), equalTo(false));
+        assertThat(active.values(), hasItem(sameInstance(login)));
+    }
+
+    @Test
+    public void removeActiveLogin_shouldRemoveLoginFromActiveLoginsMap() {
+        UserLogin login = buildLogin(1, "ignored");
+
+        UserLoginTracker.addActiveLogin(login);
+        UserLoginTracker.removeActiveLogin(login);
+
+        Map<String, UserLogin> active = UserLoginTracker.getActiveLogins();
+        assertThat(active.values(), not(hasItem(sameInstance(login))));
+    }
+
+    @Test
+    public void getActiveLogins_shouldReturnUnmodifiableMap() {
+        UserLogin login = buildLogin(1, "ignored");
+
+        UserLoginTracker.addActiveLogin(login);
+        Map<String, UserLogin> active = UserLoginTracker.getActiveLogins();
+
+        assertThat(active.isEmpty(), equalTo(false));
+
+        // The returned map should be unmodifiable
+        try {
+            active.clear();
+            assertThat("Expected getActiveLogins() to return an unmodifiable map", false);
+        } catch (UnsupportedOperationException ex) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for UserLoginTracker

1. Verifies that setLoginOnThread / getLoginOnThread / removeLoginFromThread correctly manage the thread‑local UserLogin
2. Verifies that addActiveLogin / removeActiveLogin maintain the global map of active logins
3. Ensures that getActiveLogins returns an unmodifiable view of the active login map

These tests improve coverage around how the authentication module tracks active and per‑thread user login sessions.