### PR TITLE
AUT-6: strip whitespace from TOTP code before verification

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
@@ -13,17 +13,8 @@
  */
 package org.openmrs.module.authentication.web;
 
-import dev.samstevens.totp.code.CodeGenerator;
-import dev.samstevens.totp.code.DefaultCodeGenerator;
-import dev.samstevens.totp.code.DefaultCodeVerifier;
-import dev.samstevens.totp.code.HashingAlgorithm;
-import dev.samstevens.totp.qr.QrData;
-import dev.samstevens.totp.qr.QrGenerator;
-import dev.samstevens.totp.qr.ZxingPngQrGenerator;
-import dev.samstevens.totp.secret.DefaultSecretGenerator;
-import dev.samstevens.totp.time.SystemTimeProvider;
-import dev.samstevens.totp.time.TimeProvider;
-import dev.samstevens.totp.util.Utils;
+import java.util.Properties;
+
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.User;
 import org.openmrs.api.context.Authenticated;
@@ -35,7 +26,17 @@ import org.openmrs.module.authentication.AuthenticationUtil;
 import org.openmrs.module.authentication.UserLogin;
 import org.openmrs.util.Security;
 
-import java.util.Properties;
+import dev.samstevens.totp.code.CodeGenerator;
+import dev.samstevens.totp.code.DefaultCodeGenerator;
+import dev.samstevens.totp.code.DefaultCodeVerifier;
+import dev.samstevens.totp.code.HashingAlgorithm;
+import dev.samstevens.totp.qr.QrData;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.qr.ZxingPngQrGenerator;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.time.SystemTimeProvider;
+import dev.samstevens.totp.time.TimeProvider;
+import dev.samstevens.totp.util.Utils;
 
 /**
  * This supports configuring and validating against a TOTP provider using something like Google Authenticator
@@ -123,9 +124,10 @@ public class TotpAuthenticationScheme extends WebAuthenticationScheme {
 			return credentials;
 		}
 		String code = session.getRequestParam(codeParam);
-		if (StringUtils.isNotBlank(code)) {
-			User candidateUser = session.getUserLogin().getUser();
-			credentials = new TotpAuthenticationScheme.TotpCredentials(candidateUser, code);
+if (StringUtils.isNotBlank(code)) {
+    code = code.trim();
+    User candidateUser = session.getUserLogin().getUser();
+    credentials = new TotpAuthenticationScheme.TotpCredentials(candidateUser, code);
 			session.getUserLogin().addUnvalidatedCredentials(credentials);
 			return credentials;
 		}


### PR DESCRIPTION
Fixes [AUT-6] (https://openmrs.atlassian.net/browse/AUT-6)

## Problem

When someone copies a TOTP code from an authenticator app like Google Authenticator, the copied text sometimes includes a space in the middle - for example `123 456` instead of `123456`. The verification was failing for these users even though their code was completely correct.

## Fix

Strip all whitespace from the code right after it's read from the request, before passing it to the verifier. One line added in `TotpAuthenticationScheme.getCredentials()`.

[AUT-6]: https://openmrs.atlassian.net/browse/AUT-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ