### PR TITLE
(fix) Parse Basic auth header per RFC 7235 and RFC 7617

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/BasicWebAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/BasicWebAuthenticationScheme.java
@@ -95,13 +95,20 @@ public class BasicWebAuthenticationScheme extends WebAuthenticationScheme {
         }
         else {
             String authHeader = session.getRequestHeader(AUTHORIZATION_HEADER);
-            if (StringUtils.isNotBlank(authHeader)) {
-                // Expected format:  "Basic ${base64encode(username + ":" + password)}"
+            if (StringUtils.isNotBlank(authHeader)
+                    && authHeader.length() > 6
+                    && authHeader.regionMatches(true, 0, "Basic ", 0, 6)) {
                 try {
-                    authHeader = authHeader.substring(6); // remove the leading "Basic "
-                    String decodedAuthHeader = new String(Base64.decodeBase64(authHeader), StandardCharsets.UTF_8);
-                    String[] userAndPass = decodedAuthHeader.split(":");
-                    credentials = new BasicCredentials(userAndPass[0], userAndPass[1]);
+                    String encoded = authHeader.substring(6);
+                    String decoded = new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8);
+                    // RFC 7617 §2: the first ':' separates user-id from password; the password itself may contain ':'.
+                    int firstColon = decoded.indexOf(':');
+                    if (firstColon > 0) {
+                        credentials = new BasicCredentials(decoded.substring(0, firstColon), decoded.substring(firstColon + 1));
+                    }
+                    else {
+                        session.setErrorMessage("authentication.error.invalidCredentials");
+                    }
                 }
                 catch (Exception e) {
                     session.setErrorMessage("authentication.error.invalidCredentials");

--- a/omod/src/main/java/org/openmrs/module/authentication/web/BasicWebAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/BasicWebAuthenticationScheme.java
@@ -96,7 +96,6 @@ public class BasicWebAuthenticationScheme extends WebAuthenticationScheme {
         else {
             String authHeader = session.getRequestHeader(AUTHORIZATION_HEADER);
             if (StringUtils.isNotBlank(authHeader)
-                    && authHeader.length() > 6
                     && authHeader.regionMatches(true, 0, "Basic ", 0, 6)) {
                 try {
                     String encoded = authHeader.substring(6);

--- a/omod/src/test/java/org/openmrs/module/authentication/web/BasicWebAuthenticationSchemeTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/BasicWebAuthenticationSchemeTest.java
@@ -137,16 +137,14 @@ public class BasicWebAuthenticationSchemeTest extends BaseWebAuthenticationTest 
 
 	@Test
 	public void shouldAcceptLowercaseBasicScheme() {
-		String encoded = new String(Base64.encodeBase64("admin:adminPassword".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-		AuthenticationCredentials credentials = getCredentialsFromHeader("basic " + encoded);
+		AuthenticationCredentials credentials = getCredentialsFromHeader("basic " + encoded("admin:adminPassword"));
 		assertThat(credentials, notNullValue());
 		assertThat(credentials.getClientName(), equalTo("admin"));
 	}
 
 	@Test
 	public void shouldAcceptMixedCaseBasicScheme() {
-		String encoded = new String(Base64.encodeBase64("admin:adminPassword".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-		AuthenticationCredentials credentials = getCredentialsFromHeader("BaSiC " + encoded);
+		AuthenticationCredentials credentials = getCredentialsFromHeader("BaSiC " + encoded("admin:adminPassword"));
 		assertThat(credentials, notNullValue());
 		assertThat(credentials.getClientName(), equalTo("admin"));
 	}
@@ -166,8 +164,7 @@ public class BasicWebAuthenticationSchemeTest extends BaseWebAuthenticationTest 
 
 	@Test
 	public void shouldReturnNullForMalformedBasicHeaderWithoutColon() {
-		String encoded = new String(Base64.encodeBase64("nocolonhere".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-		assertThat(getCredentialsFromHeader("Basic " + encoded), nullValue());
+		assertThat(getCredentialsFromHeader("Basic " + encoded("nocolonhere")), nullValue());
 	}
 
 	protected AuthenticationCredentials getCredentialsFromHeader(String authHeader) {
@@ -182,6 +179,10 @@ public class BasicWebAuthenticationSchemeTest extends BaseWebAuthenticationTest 
 	}
 
 	private static String basic(String userAndPass) {
-		return "Basic " + new String(Base64.encodeBase64(userAndPass.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+		return "Basic " + encoded(userAndPass);
+	}
+
+	private static String encoded(String userAndPass) {
+		return new String(Base64.encodeBase64(userAndPass.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/authentication/web/BasicWebAuthenticationSchemeTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/BasicWebAuthenticationSchemeTest.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.authentication.web;
 
+import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,8 @@ import org.openmrs.module.authentication.web.mocks.MockBasicWebAuthenticationSch
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -122,5 +125,63 @@ public class BasicWebAuthenticationSchemeTest extends BaseWebAuthenticationTest 
 	public void shouldFailToAuthenticateIfCredentialsAreIncorrectType() {
 		TestAuthenticationCredentials creds = new TestAuthenticationCredentials("test", new User());
 		assertThrows(ContextAuthenticationException.class, () -> authenticationScheme.authenticate(creds));
+	}
+
+	@Test
+	public void shouldReadCredentialsFromBasicAuthorizationHeader() {
+		AuthenticationCredentials credentials = getCredentialsFromHeader(basic("admin:adminPassword"));
+		assertThat(credentials, notNullValue());
+		assertThat(credentials.getClientName(), equalTo("admin"));
+		assertThat(credentials.getAuthenticationScheme(), equalTo("basic"));
+	}
+
+	@Test
+	public void shouldAcceptLowercaseBasicScheme() {
+		String encoded = new String(Base64.encodeBase64("admin:adminPassword".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+		AuthenticationCredentials credentials = getCredentialsFromHeader("basic " + encoded);
+		assertThat(credentials, notNullValue());
+		assertThat(credentials.getClientName(), equalTo("admin"));
+	}
+
+	@Test
+	public void shouldAcceptMixedCaseBasicScheme() {
+		String encoded = new String(Base64.encodeBase64("admin:adminPassword".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+		AuthenticationCredentials credentials = getCredentialsFromHeader("BaSiC " + encoded);
+		assertThat(credentials, notNullValue());
+		assertThat(credentials.getClientName(), equalTo("admin"));
+	}
+
+	@Test
+	public void shouldPreserveColonsInPassword() {
+		AuthenticationCredentials credentials = getCredentialsFromHeader(basic("admin:pa:ss:word"));
+		assertThat(credentials, notNullValue());
+		assertThat(credentials.getClientName(), equalTo("admin"));
+		assertThat(((BasicWebAuthenticationScheme.BasicCredentials) credentials).getPassword(), equalTo("pa:ss:word"));
+	}
+
+	@Test
+	public void shouldIgnoreNonBasicAuthorizationScheme() {
+		assertThat(getCredentialsFromHeader("Bearer someOpaqueToken"), nullValue());
+	}
+
+	@Test
+	public void shouldReturnNullForMalformedBasicHeaderWithoutColon() {
+		String encoded = new String(Base64.encodeBase64("nocolonhere".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+		assertThat(getCredentialsFromHeader("Basic " + encoded), nullValue());
+	}
+
+	protected AuthenticationCredentials getCredentialsFromHeader(String authHeader) {
+		request = newPostRequest("192.168.1.1", "/login");
+		if (authHeader != null) {
+			request.addHeader("Authorization", authHeader);
+		}
+		request.setSession(session);
+		response = newResponse();
+		authenticationSession = new MockAuthenticationSession(request, response);
+		return authenticationScheme.getCredentials(authenticationSession);
+	}
+
+	private static String basic(String userAndPass) {
+		return "Basic " + new String(Base64.encodeBase64(userAndPass.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 	}
 }


### PR DESCRIPTION
## Summary
`BasicWebAuthenticationScheme.getCredentials` now validates the `Authorization` header against a case-insensitive `Basic ` prefix (RFC 7235 §2.1) and splits the decoded credentials on the first colon only (RFC 7617 §2). Non-Basic schemes are ignored instead of being mangled into a failed Base64 decode.

## Why
Two silent failures for real users: (1) any user whose password contains `:` cannot authenticate via HTTP Basic — the first colon truncates the password; (2) every `Bearer`/`Digest` request currently logs a WARN stack trace because the code blindly strips six leading characters and Base64-decodes the remainder. The fix is bounded to one method and adds six focused tests.

## Testing
- `shouldReadCredentialsFromBasicAuthorizationHeader` — baseline, header path intact.
- `shouldAcceptLowercaseBasicScheme` / `shouldAcceptMixedCaseBasicScheme` — RFC 7235 §2.1 case-insensitivity.
- `shouldPreserveColonsInPassword` — RFC 7617 §2; fails on `main`, passes with the fix.
- `shouldIgnoreNonBasicAuthorizationScheme` — `Bearer …` no longer produces WARN noise or an invalid-credentials error on the session.
- `shouldReturnNullForMalformedBasicHeaderWithoutColon` — no exception escapes `getCredentials`.
- `mvn -DskipITs test` — full suite green locally: 113 tests, 0 failures, 0 errors.

## Related
N/A

cc @jayasanka-sack