### PR TITLE
Add on-demand Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,20 @@
+# On-demand PR review by Claude, invoked by commenting "@claude review" on a PR.
+# The logic lives in a shared reusable workflow so every OpenMRS repo stays in
+# sync; see openmrs/openmrs-contrib-gha-workflows. Tracking @main while the
+# reusable is still being refined, so changes flow through without editing this
+# file; this will be pinned to a @v1 tag once it stabilises. Defaults there are
+# Sonnet 5 at medium effort; override via `with:` if needed.
+name: Claude PR Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write


### PR DESCRIPTION
Adds the thin caller for the org's reusable Claude PR-review workflow (openmrs/openmrs-contrib-gha-workflows), so /dev/3+ members can request a review by commenting "@claude review" on a PR here.

Copied from openmrs-module-metadataexport with two corrections against the current reusable workflow: the header comment now states the actual defaults (Sonnet 5, medium effort, not Opus 4.8 at max), and the id-token: write permission is dropped since the reusable workflow deliberately avoids the OIDC/App-token path and its documented usage omits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)