### PR TITLE
AUT-6: Normalize whitespaces from the totp code

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
@@ -196,6 +196,9 @@ public class TotpAuthenticationScheme extends WebAuthenticationScheme implements
 	 * @return true if the entered code is valid for the given secret
 	 */
 	public boolean verifyCode(String secret, String code) {
+		if (code != null) {
+			code = StringUtils.deleteWhitespace(code);
+		}
 		TimeProvider timeProvider = new SystemTimeProvider();
 		CodeGenerator codeGenerator = new DefaultCodeGenerator(hashingAlgorithm, codeLength);
 		DefaultCodeVerifier verifier = new DefaultCodeVerifier(codeGenerator, timeProvider);

--- a/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.UserService;
-import org.openmrs.api.context.Authenticated;
 import org.openmrs.api.context.AuthenticationScheme;
 import org.openmrs.api.context.BasicAuthenticated;
 import org.openmrs.api.context.Context;
@@ -24,7 +23,6 @@ import org.openmrs.module.authentication.web.mocks.MockTotpAuthenticationScheme;
 import org.openmrs.module.authentication.web.mocks.MockTwoFactorAuthenticationScheme;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
-import org.openmrs.util.Security;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 

--- a/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.UserService;
+import org.openmrs.api.context.Authenticated;
 import org.openmrs.api.context.AuthenticationScheme;
 import org.openmrs.api.context.BasicAuthenticated;
 import org.openmrs.api.context.Context;
@@ -23,6 +24,7 @@ import org.openmrs.module.authentication.web.mocks.MockTotpAuthenticationScheme;
 import org.openmrs.module.authentication.web.mocks.MockTwoFactorAuthenticationScheme;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.util.Security;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 
@@ -319,5 +321,11 @@ public class TotpAuthenticationSchemeTest extends BaseWebAuthenticationTest {
 		public User getAuthenticatedUser() {
 			return user;
 		}
+	}
+	
+	@Test
+	public void shouldRemoveSpacesFromTotpVerificationCode() {
+		boolean isValid = authenticationScheme.verifyCode("123456", " 123 456 ");
+		assertThat(isValid, equalTo(true));
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/TotpAuthenticationSchemeTest.java
@@ -322,7 +322,7 @@ public class TotpAuthenticationSchemeTest extends BaseWebAuthenticationTest {
 	}
 	
 	@Test
-	public void shouldRemoveSpacesFromTotpVerificationCode() {
+	public void shouldAcceptVerificationCodeContainingSpaces() {
 		boolean isValid = authenticationScheme.verifyCode("123456", " 123 456 ");
 		assertThat(isValid, equalTo(true));
 	}

--- a/omod/src/test/java/org/openmrs/module/authentication/web/mocks/MockTotpAuthenticationScheme.java
+++ b/omod/src/test/java/org/openmrs/module/authentication/web/mocks/MockTotpAuthenticationScheme.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.authentication.web.mocks;
 
+import org.apache.commons.lang.StringUtils;
 import org.openmrs.User;
 import org.openmrs.module.authentication.web.TotpAuthenticationScheme;
 
@@ -19,6 +20,9 @@ public class MockTotpAuthenticationScheme extends TotpAuthenticationScheme {
 
     @Override
     public boolean verifyCode(String secret, String code) {
+        if (code != null) {
+            code = StringUtils.deleteWhitespace(code);
+        }
         return code != null && code.equals(secret);
     }
     


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work includes tests or is validated by existing tests.

## Summary
I raise this PR to normalize the verification code by stripping out all whitespaces before validating it. I used `StringUtils.deleteWhitespace` to strip all whitespace from the totp code instead of a simple `trim()` because it only removes leading and trailing whitespace. but if the user inputs "123 456" (which Microsoft Authenticator displays with a space between the 3rd and 4th digit), `trim()` wouldn't do our work. 

## Screenshots
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/AUT-6

## Other
N/A