### PR TITLE
AUT-28: Fix username display in TOTP authenticator apps

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TotpAuthenticationScheme.java
@@ -247,7 +247,7 @@ public class TotpAuthenticationScheme extends WebAuthenticationScheme implements
 		}
 		
 		String secret = generateSecret();
-		String qrCodeUri = generateQrCodeUriForSecret(secret, user.getUsername());
+		String qrCodeUri = generateQrCodeUriForSecret(secret, user.toString());
 		
 		request.getSession().setAttribute(PENDING_ENROLLMENT_SECRET, secret);
 		request.getSession().setAttribute(PENDING_ENROLLMENT_TIME, System.currentTimeMillis());


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue where the user's account username is blank in authenticator app after scanning the totp setup qr code.

## Screenshots
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/AUT-28

## Other
N/A