### PR TITLE
AUT-30: Fix secondary authentication not saving to DB

### DIFF
--- a/omod/src/main/java/org/openmrs/module/authentication/web/TwoFactorAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TwoFactorAuthenticationScheme.java
@@ -330,7 +330,7 @@ public class TwoFactorAuthenticationScheme extends WebAuthenticationScheme {
 		List<String> schemeIds = getSecondaryAuthenticationSchemeIdsForUser(user);
 		if (!schemeIds.contains(schemeId)) {
 			schemeIds.add(schemeId);
-			Context.getUserService().setUserProperty(user, USER_PROPERTY_SECONDARY_TYPE, String.join(",", schemeId));
+			Context.getUserService().setUserProperty(user, USER_PROPERTY_SECONDARY_TYPE, String.join(",", schemeIds));
 		}
 	}
 

--- a/omod/src/main/java/org/openmrs/module/authentication/web/TwoFactorAuthenticationScheme.java
+++ b/omod/src/main/java/org/openmrs/module/authentication/web/TwoFactorAuthenticationScheme.java
@@ -330,7 +330,7 @@ public class TwoFactorAuthenticationScheme extends WebAuthenticationScheme {
 		List<String> schemeIds = getSecondaryAuthenticationSchemeIdsForUser(user);
 		if (!schemeIds.contains(schemeId)) {
 			schemeIds.add(schemeId);
-			user.setUserProperty(USER_PROPERTY_SECONDARY_TYPE, String.join(",", schemeIds));
+			Context.getUserService().setUserProperty(user, USER_PROPERTY_SECONDARY_TYPE, String.join(",", schemeId));
 		}
 	}
 


### PR DESCRIPTION
This PR is going to fix the bug where secondary authentication scheme (TOTP) fail to save to the database.

Ticket: https://openmrs.atlassian.net/browse/AUT-30